### PR TITLE
remove brew cask update command

### DIFF
--- a/brew-cask-upgrade-all.rb
+++ b/brew-cask-upgrade-all.rb
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-puts "brew cask update:"
-puts `brew cask update`
 puts "brew upgrade:"
 puts `brew upgrade`
 


### PR DESCRIPTION
Because of this warning:

Warning: Calling `brew cask update` is deprecated and will be disabled
on 2017-07-01!

See
https://github.com/Homebrew/brew/commit/a1154e9fabcca4feca629f86e86d139768f0de48